### PR TITLE
Use DATABASE_URL as default value of DSN

### DIFF
--- a/sqlrunner/__main__.py
+++ b/sqlrunner/__main__.py
@@ -1,9 +1,10 @@
+import os
 import sys
 
 from sqlrunner import main
 
 
-args = main.parse_args(sys.argv[1:])
+args = main.parse_args(sys.argv[1:], os.environ)
 sql_query = main.read_text(args.input)
 results = main.run_sql(dsn=args.dsn, sql_query=sql_query)
 main.write_results(results, args.output)

--- a/sqlrunner/__main__.py
+++ b/sqlrunner/__main__.py
@@ -1,7 +1,9 @@
+import sys
+
 from sqlrunner import main
 
 
-args = main.parse_args()
+args = main.parse_args(sys.argv[1:])
 sql_query = main.read_text(args.input)
 results = main.run_sql(dsn=args.dsn, sql_query=sql_query)
 main.write_results(results, args.output)

--- a/sqlrunner/main.py
+++ b/sqlrunner/main.py
@@ -8,7 +8,7 @@ import pymssql
 from sqlrunner import __version__
 
 
-def parse_args():
+def parse_args(args):
     parser = argparse.ArgumentParser()
     parser.add_argument(
         "--dsn",
@@ -29,7 +29,7 @@ def parse_args():
     parser.add_argument(
         "--version", action="version", version=f"sqlrunner {__version__}"
     )
-    return parser.parse_args()
+    return parser.parse_args(args)
 
 
 def read_text(f_path):

--- a/sqlrunner/main.py
+++ b/sqlrunner/main.py
@@ -8,11 +8,12 @@ import pymssql
 from sqlrunner import __version__
 
 
-def parse_args(args):
+def parse_args(args, environ=None):
+    environ = environ or {}
     parser = argparse.ArgumentParser()
     parser.add_argument(
         "--dsn",
-        required=True,
+        default=environ.get("DATABASE_URL"),
         help="Data Source Name",
     )
     parser.add_argument(

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -21,6 +21,19 @@ def test_parse_args():
     assert args.output == pathlib.Path("results.csv")
 
 
+def test_parse_args_with_defaults_from_environ(monkeypatch):
+    # act
+    args = main.parse_args(
+        ["--output", "results.csv", "query.sql"],
+        {"DATABASE_URL": "dialect+driver://user:password@server:port/database"},
+    )
+
+    # assert
+    assert args.dsn == "dialect+driver://user:password@server:port/database"
+    assert args.input == pathlib.Path("query.sql")
+    assert args.output == pathlib.Path("results.csv")
+
+
 def test_read_text(tmp_path):
     # arrange
     f_path = tmp_path / "query.sql"

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -3,22 +3,17 @@ import pathlib
 from sqlrunner import main
 
 
-def test_parse_args(monkeypatch):
-    # arrange
-    monkeypatch.setattr(
-        "sys.argv",
+def test_parse_args():
+    # act
+    args = main.parse_args(
         [
-            "main.py",
             "--dsn",
             "dialect+driver://user:password@server:port/database",
             "--output",
             "results.csv",
             "query.sql",
-        ],
+        ]
     )
-
-    # act
-    args = main.parse_args()
 
     # assert
     assert args.dsn == "dialect+driver://user:password@server:port/database"


### PR DESCRIPTION
7fb7e85 is a small refactoring that prepares the ground for 95d7ae9, which is the substantive feature. The commit message explains the what and why:

> Use DATABASE_URL as default value of DSN
> 
> We don't want a user to hard-code a DSN in a project.yaml, because
> that's insecure. DATABASE_URL is available to all actions that have
> database (i.e.  network) access, but we don't want a user to pass `--dsn
> $DATABASE_URL` either, because whether the string is evaluated depends
> on job-runner's implementation. So we use DATABASE_URL as the default
> value of DSN.
> 
> We add test_parse_args_with_defaults_from_environ rather than
> parameterize test_parse_args because the number and length of the
> parameters would have made the test hard to reason about.