### PR TITLE
Switch base-docker from 20.04 to 22.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 #
 # Create an image for system dependencies
 # hadolint ignore=DL3007
-FROM ghcr.io/opensafely-core/base-docker:latest as sqlrunner-dependencies
+FROM ghcr.io/opensafely-core/base-docker:22.04 as sqlrunner-dependencies
 
 # Default env vars for all images
 ENV VIRTUAL_ENV=/opt/venv \
@@ -19,14 +19,6 @@ WORKDIR /workspace
 # We are going to use an apt cache on the host, so we disable the default Debian Docker
 # clean up that deletes that cache on every apt install.
 RUN rm -f /etc/apt/apt.conf.d/docker-clean
-
-# Install python3.10 from deadsnakes PPA. See:
-# https://gist.github.com/tiran/2dec9e03c6f901814f6d1e8dad09528e
-# Use space-efficient utility from base-docker
-RUN --mount=type=cache,target=/var/cache/apt \
-    echo "deb http://ppa.launchpad.net/deadsnakes/ppa/ubuntu focal main" > /etc/apt/sources.list.d/deadsnakes-ppa.list &&\
-    /usr/lib/apt/apt-helper download-file 'https://keyserver.ubuntu.com/pks/lookup?op=get&search=0xf23c5a6cf475977595c89f51ba6932366a755776' /etc/apt/trusted.gpg.d/deadsnakes.asc &&\
-    /root/docker-apt-install.sh python3.10 python3.10-venv python3.10-distutils tzdata ca-certificates
 
 # Install system dependencies
 COPY dependencies.txt /root/dependencies.txt
@@ -44,7 +36,7 @@ RUN /root/docker-apt-install.sh /root/build-dependencies.txt
 
 # Create a virtualenv for isolation from system Python
 RUN --mount=type=cache,target=/root/.cache \
-    python3.10 -m venv /opt/venv && \
+    python3 -m venv /opt/venv && \
     /opt/venv/bin/python -m pip install -U pip
 
 # Install Python dependencies into the virtualenv

--- a/dependencies.txt
+++ b/dependencies.txt
@@ -1,1 +1,6 @@
 # system dependencies, one per line
+ca-certificates
+python3
+python3-distutils
+python3-venv
+tzdata


### PR DESCRIPTION
20.04 (latest) does not come with Python 3.10, so we have to install it from deadsnakes. However, 22.04 does, so we can remove deadsnakes.