### PR TITLE
Optimize build by copying only package to image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -70,4 +70,4 @@ FROM sqlrunner-base as sqlrunner
 ENTRYPOINT ["python", "-m", "sqlrunner"]
 
 # Copy the application code
-COPY . /app
+COPY sqlrunner /app/sqlrunner


### PR DESCRIPTION
Previously, we copied the contents of the project directory to the image. The contents of this directory are likely to change often, because Dependabot is configured to check dependencies every week.

A change to production dependencies should trigger a layer (and its downstream layers) to be rebuilt; indeed, it does, but earlier in the Dockerfile. A change to development dependencies should not trigger a layer (and its downstream layers) to be rebuilt, however. To prevent this, we copy only the package to the image, rather than the contents of the project directory.