### PR TITLE
Unquote user and password credentials

### DIFF
--- a/sqlrunner/main.py
+++ b/sqlrunner/main.py
@@ -44,8 +44,8 @@ def run_sql(*, dsn, sql_query):
     parsed_dsn = parse.urlparse(dsn)
 
     conn = pymssql.connect(
-        user=parsed_dsn.username,
-        password=parsed_dsn.password,
+        user=parse.unquote(parsed_dsn.username),
+        password=parse.unquote(parsed_dsn.password),
         server=parsed_dsn.hostname,
         port=parsed_dsn.port,
         database=parsed_dsn.path.strip("/"),


### PR DESCRIPTION
The user and password credentials may be quoted; that is, they may contain special characters that have been escaped with `%xx`. If they are (or do), then we should unquote them.

This behaviour mirrors cohort-extractor. See
`cohortextractor.mssql_utils.mssql_connection_params_from_url`. Thanks for spotting this, @bloodearnest.