### PR TITLE
Ignore `--dummy-data-file` in production

### DIFF
--- a/sqlrunner/__main__.py
+++ b/sqlrunner/__main__.py
@@ -5,9 +5,10 @@ from sqlrunner import main
 
 
 args = main.parse_args(sys.argv[1:], os.environ)
-sql_query = main.read_text(args.input)
-if args.dummy_data_file is None:
-    results = main.run_sql(dsn=args.dsn, sql_query=sql_query)
-else:
+if args.dsn is None and args.dummy_data_file is not None:
+    # Bypass the database
     results = args.dummy_data_file
+else:
+    sql_query = main.read_text(args.input)
+    results = main.run_sql(dsn=args.dsn, sql_query=sql_query)
 main.write_results(results, args.output)


### PR DESCRIPTION
This allows us to commit `--dummy-data-file` to *project.yaml*, such that the associated SQL Runner action is run against dummy data when run locally and when run in CI, but run against a database when run in production.

You'll notice that whilst the functions called from *\_\_main__.py* are tested, the `if`/`else` within *\_\_main__.py* is not. This follows the advice within the Python documentation. For more information, see: https://docs.python.org/3.10/library/__main__.html?highlight=__main__%20py#id1

I briefly considered making `--dummy-data-file` and `--dsn` mutually exclusive with `ArgumentParser.add_mutually_exclusive_group`, but the point here is to commit both to *project.yaml*.

Closes #46