### PR TITLE
Placate flake8

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,9 +1,13 @@
 [flake8]
 extend-exclude = .direnv,.venv,venv
-extend-select = \
-    W504  # match black&PEP8 putting binary operators after new lines
-ignore = \
-    E203 \ # whitespace before : (black disagrees)
-    E501 \ # line too long (black fixes long lines, except for long strings which may benefit from being long (eg URLs))
-    W503   # line break before binary operator (black disagrees)
+extend-select =
+    # match black&PEP8 putting binary operators after new lines
+    W504
+ignore =
+    # whitespace before : (black disagrees)
+    E203
+    # line too long (black fixes long lines, except for long strings which may benefit from being long (eg URLs))
+    E501
+    # line break before binary operator (black disagrees)
+    W503
 max-line-length = 88


### PR DESCRIPTION
flake8 v6 seems to be particular about inline comments (see the note at [1]) and line continuation characters.

[1]: https://flake8.pycqa.org/en/stable/user/configuration.html