### PR TITLE
Add logging

### DIFF
--- a/requirements.prod.in
+++ b/requirements.prod.in
@@ -4,3 +4,4 @@
 # pip-compile --generate-hashes --output-file=requirements.prod.txt requirements.prod.in
 
 pymssql
+structlog

--- a/requirements.prod.txt
+++ b/requirements.prod.txt
@@ -38,3 +38,7 @@ pymssql==2.2.8 \
     --hash=sha256:e920d6f805a525f19e770e48326a5f96b83d7b8dfd093f5b7015b54ef84bcf4c \
     --hash=sha256:ebe7f64d5278d807f14bea08951e02512bfbc6219fd4d4f15bb45ded885cf3d4
     # via -r requirements.prod.in
+structlog==23.1.0 \
+    --hash=sha256:270d681dd7d163c11ba500bc914b2472d2b50a8ef00faa999ded5ff83a2f906b \
+    --hash=sha256:79b9e68e48b54e373441e130fa447944e6f87a05b35de23138e475c05d0f7e0e
+    # via -r requirements.prod.in

--- a/sqlrunner/main.py
+++ b/sqlrunner/main.py
@@ -40,7 +40,11 @@ def parse_args(args, environ=None):
         type=pathlib.Path,
         help="Path to the input dummy data file to be used as the output CSV file",
     )
-
+    parser.add_argument(
+        "--log-file",
+        type=pathlib.Path,
+        help="Path to the log file",
+    )
     parser.add_argument(
         "--version", action="version", version=f"sqlrunner {__version__}"
     )

--- a/sqlrunner/main.py
+++ b/sqlrunner/main.py
@@ -103,8 +103,10 @@ def write_results(results, f_path):
 
     try:
         writer = csv.DictWriter(f, fieldnames)
+        log.info("start_writing_results")
         writer.writeheader()
         writer.writerows(itertools.chain([first_result], results))
+        log.info("finish_writing_results")
     finally:
         f.close()
 

--- a/sqlrunner/main.py
+++ b/sqlrunner/main.py
@@ -8,8 +8,12 @@ import shutil
 from urllib import parse
 
 import pymssql
+import structlog
 
 from sqlrunner import __version__
+
+
+log = structlog.get_logger()
 
 
 def parse_args(args, environ=None):
@@ -65,7 +69,9 @@ def run_sql(*, dsn, sql_query):
     parsed_dsn = parse_dsn(dsn)
     conn = pymssql.connect(**parsed_dsn, as_dict=True)
     cursor = conn.cursor()
+    log.info("start_executing_sql_query")
     cursor.execute(sql_query)
+    log.info("finish_executing_sql_query")
     yield from cursor
     conn.close()
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,6 @@
 import pytest
+import structlog
+from structlog.testing import LogCapture
 
 from .databases import make_mssql_database, wait_for_database
 from .docker import Containers
@@ -14,3 +16,13 @@ def mssql_database(containers):
     database = make_mssql_database(containers)
     wait_for_database(database)
     yield database
+
+
+@pytest.fixture
+def log_output():
+    return LogCapture()
+
+
+@pytest.fixture(autouse=True)
+def configure_structlog(log_output):
+    structlog.configure(processors=[log_output])

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -23,6 +23,7 @@ def test_parse_args():
     assert args.input == pathlib.Path("query.sql")
     assert args.output == pathlib.Path("results.csv")
     assert args.dummy_data_file is None
+    assert args.log_file is None
 
 
 def test_parse_args_with_defaults_from_environ(monkeypatch):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -63,7 +63,7 @@ def test_parse_dsn(dsn, port):
     assert parsed_dsn["port"] == port
 
 
-def test_run_sql(mssql_database):
+def test_run_sql(mssql_database, log_output):
     # arrange
     dialect = "mssql"
     driver = "pymssql"
@@ -79,6 +79,10 @@ def test_run_sql(mssql_database):
 
     # assert
     assert list(results) == [{"patient_id": 1}]
+    assert log_output.entries == [
+        {"event": "start_executing_sql_query", "log_level": "info"},
+        {"event": "finish_executing_sql_query", "log_level": "info"},
+    ]
 
 
 @pytest.fixture(params=["", "subdir"])

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -110,7 +110,7 @@ def test_write_zero_results(output_path):
     assert f_path.read_text(encoding="utf-8") == ""
 
 
-def test_write_results(output_path):
+def test_write_results(output_path, log_output):
     # arrange
     f_path = output_path / "results.csv"
 
@@ -119,6 +119,10 @@ def test_write_results(output_path):
 
     # assert
     assert f_path.read_text(encoding="utf-8") == "id\n1\n2\n"
+    assert log_output.entries == [
+        {"event": "start_writing_results", "log_level": "info"},
+        {"event": "finish_writing_results", "log_level": "info"},
+    ]
 
 
 def test_write_results_compressed(output_path):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -99,22 +99,26 @@ def output_path(tmp_path, request):
     return tmp_path / request.param
 
 
-@pytest.mark.parametrize(
-    "results,csv_string",
-    [
-        ([{"id": 1}, {"id": 2}], "id\n1\n2\n"),
-        ([], ""),  # zero results
-    ],
-)
-def test_write_results(output_path, results, csv_string):
+def test_write_zero_results(output_path):
     # arrange
     f_path = output_path / "results.csv"
 
     # act
-    main.write_results(iter(results), f_path)  # `results` should be an iterator
+    main.write_results(iter([]), f_path)
 
     # assert
-    assert f_path.read_text(encoding="utf-8") == csv_string
+    assert f_path.read_text(encoding="utf-8") == ""
+
+
+def test_write_results(output_path):
+    # arrange
+    f_path = output_path / "results.csv"
+
+    # act
+    main.write_results(iter([{"id": 1}, {"id": 2}]), f_path)
+
+    # assert
+    assert f_path.read_text(encoding="utf-8") == "id\n1\n2\n"
 
 
 def test_write_results_compressed(output_path):


### PR DESCRIPTION
#86 asks for metadata. However, after discussing the issue with @ghickman, I think it should ask for logging. This is because adding logging would provide finer-grained information (3f182b0, bf6bba1) and would mean SQL Runner actions fit better into an `opensafely exec` workflow.

We want to write logs to a file (for downstream actions) and to stdout (for `opensafely exec`). Ideally, we'd format the former as JSON and the latter as text. However, doing so is [ambitious][1], so instead we take [a simpler approach][2] and format both as JSON (2feb866).

Closes #86 

[1]: https://www.structlog.org/en/stable/standard-library.html#rendering-using-structlog-based-formatters-within-logging
[2]: https://www.structlog.org/en/stable/standard-library.html#rendering-within-structlog