### PR TITLE
Make SQL Runner less gangly

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,6 @@ omit = [".venv/*"]
 fail_under = 100
 skip_covered = true
 show_missing = true
-omit = ["sqlrunner/__main__.py"]
 
 [tool.coverage.html]
 show_contexts = true

--- a/sqlrunner/__init__.py
+++ b/sqlrunner/__init__.py
@@ -3,4 +3,4 @@ from pathlib import Path
 
 __version__ = Path(__file__).parent.joinpath("VERSION").read_text().strip()
 
-T100S_TABLE = "PatientsWithTypeOneDissent"
+T1OOS_TABLE = "PatientsWithTypeOneDissent"

--- a/sqlrunner/__main__.py
+++ b/sqlrunner/__main__.py
@@ -79,13 +79,7 @@ def entrypoint():
         handlers.append(logging.FileHandler(args["log_file"], "w"))
     logging.basicConfig(format="%(message)s", level=logging.INFO, handlers=handlers)
 
-    if args["dsn"] is None and args["dummy_data_file"] is not None:
-        # Bypass the database
-        results = args["dummy_data_file"]
-    else:
-        sql_query = main.read_text(args["input"])
-        results = main.run_sql(dsn=args["dsn"], sql_query=sql_query)
-    main.write_results(results, args["output"])
+    main.main(args)
 
 
 if __name__ == "__main__":

--- a/sqlrunner/__main__.py
+++ b/sqlrunner/__main__.py
@@ -1,10 +1,12 @@
+import argparse
 import logging
 import os
+import pathlib
 import sys
 
 import structlog
 
-from sqlrunner import main
+from sqlrunner import __version__, main
 
 
 # Configure structlog to output structured logs in JSON format. For more information,
@@ -34,8 +36,42 @@ structlog.configure(
 )
 
 
+def parse_args(args, environ):
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--dsn",
+        default=environ.get("DATABASE_URL"),
+        help="Data Source Name",
+    )
+    parser.add_argument(
+        "input",
+        type=pathlib.Path,
+        help="Path to the input SQL file",
+    )
+    parser.add_argument(
+        "--output",
+        required=True,
+        type=pathlib.Path,
+        help="Path to the output CSV file",
+    )
+    parser.add_argument(
+        "--dummy-data-file",
+        type=pathlib.Path,
+        help="Path to the input dummy data file to be used as the output CSV file",
+    )
+    parser.add_argument(
+        "--log-file",
+        type=pathlib.Path,
+        help="Path to the log file",
+    )
+    parser.add_argument(
+        "--version", action="version", version=f"sqlrunner {__version__}"
+    )
+    return parser.parse_args(args)
+
+
 def entrypoint():
-    args = main.parse_args(sys.argv[1:], os.environ)
+    args = parse_args(sys.argv[1:], os.environ)
 
     handlers = [logging.StreamHandler(sys.stdout)]
     # This is covered indirectly by a test.

--- a/sqlrunner/__main__.py
+++ b/sqlrunner/__main__.py
@@ -67,7 +67,7 @@ def parse_args(args, environ):
     parser.add_argument(
         "--version", action="version", version=f"sqlrunner {__version__}"
     )
-    return parser.parse_args(args)
+    return vars(parser.parse_args(args))
 
 
 def entrypoint():
@@ -75,17 +75,17 @@ def entrypoint():
 
     handlers = [logging.StreamHandler(sys.stdout)]
     # This is covered indirectly by a test.
-    if args.log_file is not None:  # pragma: no cover
-        handlers.append(logging.FileHandler(args.log_file, "w"))
+    if args["log_file"] is not None:  # pragma: no cover
+        handlers.append(logging.FileHandler(args["log_file"], "w"))
     logging.basicConfig(format="%(message)s", level=logging.INFO, handlers=handlers)
 
-    if args.dsn is None and args.dummy_data_file is not None:
+    if args["dsn"] is None and args["dummy_data_file"] is not None:
         # Bypass the database
-        results = args.dummy_data_file
+        results = args["dummy_data_file"]
     else:
-        sql_query = main.read_text(args.input)
-        results = main.run_sql(dsn=args.dsn, sql_query=sql_query)
-    main.write_results(results, args.output)
+        sql_query = main.read_text(args["input"])
+        results = main.run_sql(dsn=args["dsn"], sql_query=sql_query)
+    main.write_results(results, args["output"])
 
 
 if __name__ == "__main__":

--- a/sqlrunner/__main__.py
+++ b/sqlrunner/__main__.py
@@ -7,13 +7,6 @@ import structlog
 from sqlrunner import main
 
 
-args = main.parse_args(sys.argv[1:], os.environ)
-
-handlers = [logging.StreamHandler(sys.stdout)]
-if args.log_file is not None:
-    handlers.append(logging.FileHandler(args.log_file, "w"))
-logging.basicConfig(format="%(message)s", level=logging.INFO, handlers=handlers)
-
 # Configure structlog to output structured logs in JSON format. For more information,
 # see:
 # https://www.structlog.org/en/stable/standard-library.html#rendering-within-structlog
@@ -40,10 +33,24 @@ structlog.configure(
     logger_factory=structlog.stdlib.LoggerFactory(),
 )
 
-if args.dsn is None and args.dummy_data_file is not None:
-    # Bypass the database
-    results = args.dummy_data_file
-else:
-    sql_query = main.read_text(args.input)
-    results = main.run_sql(dsn=args.dsn, sql_query=sql_query)
-main.write_results(results, args.output)
+
+def entrypoint():
+    args = main.parse_args(sys.argv[1:], os.environ)
+
+    handlers = [logging.StreamHandler(sys.stdout)]
+    # This is covered indirectly by a test.
+    if args.log_file is not None:  # pragma: no cover
+        handlers.append(logging.FileHandler(args.log_file, "w"))
+    logging.basicConfig(format="%(message)s", level=logging.INFO, handlers=handlers)
+
+    if args.dsn is None and args.dummy_data_file is not None:
+        # Bypass the database
+        results = args.dummy_data_file
+    else:
+        sql_query = main.read_text(args.input)
+        results = main.run_sql(dsn=args.dsn, sql_query=sql_query)
+    main.write_results(results, args.output)
+
+
+if __name__ == "__main__":
+    entrypoint()  # pragma: no cover

--- a/sqlrunner/main.py
+++ b/sqlrunner/main.py
@@ -1,4 +1,3 @@
-import argparse
 import csv
 import functools
 import gzip
@@ -10,45 +9,10 @@ from urllib import parse
 import pymssql
 import structlog
 
-from sqlrunner import T100S_TABLE, __version__
+from sqlrunner import T100S_TABLE
 
 
 log = structlog.get_logger()
-
-
-def parse_args(args, environ=None):
-    environ = environ or {}
-    parser = argparse.ArgumentParser()
-    parser.add_argument(
-        "--dsn",
-        default=environ.get("DATABASE_URL"),
-        help="Data Source Name",
-    )
-    parser.add_argument(
-        "input",
-        type=pathlib.Path,
-        help="Path to the input SQL file",
-    )
-    parser.add_argument(
-        "--output",
-        required=True,
-        type=pathlib.Path,
-        help="Path to the output CSV file",
-    )
-    parser.add_argument(
-        "--dummy-data-file",
-        type=pathlib.Path,
-        help="Path to the input dummy data file to be used as the output CSV file",
-    )
-    parser.add_argument(
-        "--log-file",
-        type=pathlib.Path,
-        help="Path to the log file",
-    )
-    parser.add_argument(
-        "--version", action="version", version=f"sqlrunner {__version__}"
-    )
-    return parser.parse_args(args)
 
 
 def read_text(f_path):

--- a/sqlrunner/main.py
+++ b/sqlrunner/main.py
@@ -9,7 +9,7 @@ from urllib import parse
 import pymssql
 import structlog
 
-from sqlrunner import T100S_TABLE
+from sqlrunner import T1OOS_TABLE
 
 
 log = structlog.get_logger()
@@ -17,7 +17,7 @@ log = structlog.get_logger()
 
 def main(args):
     sql_query = read_text(args["input"])
-    if not are_t100s_handled(sql_query):
+    if not are_t1oos_handled(sql_query):
         raise RuntimeError("T1OOs are not handled correctly")
 
     if args["dsn"] is None and args["dummy_data_file"] is not None:
@@ -32,8 +32,8 @@ def read_text(f_path):
     return f_path.read_text(encoding="utf-8")
 
 
-def are_t100s_handled(sql_query):
-    return sql_query.find(T100S_TABLE) >= 0
+def are_t1oos_handled(sql_query):
+    return sql_query.find(T1OOS_TABLE) >= 0
 
 
 def parse_dsn(dsn):

--- a/sqlrunner/main.py
+++ b/sqlrunner/main.py
@@ -15,6 +15,16 @@ from sqlrunner import T100S_TABLE
 log = structlog.get_logger()
 
 
+def main(args):
+    if args["dsn"] is None and args["dummy_data_file"] is not None:
+        # Bypass the database
+        results = args["dummy_data_file"]
+    else:
+        sql_query = read_text(args["input"])
+        results = run_sql(dsn=args["dsn"], sql_query=sql_query)
+    write_results(results, args["output"])
+
+
 def read_text(f_path):
     return f_path.read_text(encoding="utf-8")
 

--- a/sqlrunner/main.py
+++ b/sqlrunner/main.py
@@ -16,11 +16,14 @@ log = structlog.get_logger()
 
 
 def main(args):
+    sql_query = read_text(args["input"])
+    if not are_t100s_handled(sql_query):
+        raise RuntimeError("T1OOs are not handled correctly")
+
     if args["dsn"] is None and args["dummy_data_file"] is not None:
         # Bypass the database
         results = args["dummy_data_file"]
     else:
-        sql_query = read_text(args["input"])
         results = run_sql(dsn=args["dsn"], sql_query=sql_query)
     write_results(results, args["output"])
 
@@ -49,10 +52,6 @@ def run_sql(*, dsn, sql_query):
     # <https://docs.sqlalchemy.org/en/14/core/engines.html#database-urls>
     # dialect+driver://username:password@host:port/database
     parsed_dsn = parse_dsn(dsn)
-
-    if not are_t100s_handled(sql_query):
-        raise RuntimeError("T1OOs are not handled correctly")
-
     conn = pymssql.connect(**parsed_dsn, as_dict=True)
     cursor = conn.cursor()
     log.info("start_executing_sql_query")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,6 +19,19 @@ def mssql_database(containers):
 
 
 @pytest.fixture
+def dsn(mssql_database):
+    dialect = "mssql"
+    driver = "pymssql"
+    user = mssql_database["username"]
+    password = mssql_database["password"]
+    server = mssql_database["host_from_host"]
+    port = mssql_database["port_from_host"]
+    database = mssql_database["db_name"]
+    dsn = f"{dialect}+{driver}://{user}:{password}@{server}:{port}/{database}"
+    return dsn
+
+
+@pytest.fixture
 def log_output():
     return LogCapture()
 

--- a/tests/test___main__.py
+++ b/tests/test___main__.py
@@ -25,21 +25,3 @@ def test_entrypoint(monkeypatch, tmp_path, dsn):
     entrypoint()
     assert pathlib.Path("output.csv").read_text("utf-8") == "patient_id\n1\n"
     assert pathlib.Path("log.json").exists()
-
-
-def test_entrypoint_with_dummy_data_file(monkeypatch, tmp_path):
-    monkeypatch.chdir(tmp_path)
-    pathlib.Path("dummy_data.csv").write_text("patient_id\n1\n", "utf-8")
-    monkeypatch.setattr(
-        "sys.argv",
-        [
-            "__main__",
-            "--output",
-            "output.csv",
-            "--dummy-data-file",
-            "dummy_data.csv",
-            "input.sql",
-        ],
-    )
-    entrypoint()
-    assert pathlib.Path("output.csv").read_text("utf-8") == "patient_id\n1\n"

--- a/tests/test___main__.py
+++ b/tests/test___main__.py
@@ -1,13 +1,13 @@
 import pathlib
 
-from sqlrunner import T100S_TABLE
+from sqlrunner import T1OOS_TABLE
 from sqlrunner.__main__ import entrypoint
 
 
 def test_entrypoint(monkeypatch, tmp_path, dsn):
     monkeypatch.chdir(tmp_path)
     pathlib.Path("input.sql").write_text(
-        f"-- {T100S_TABLE} intentionally not excluded\nSELECT 1 AS patient_id",
+        f"-- {T1OOS_TABLE} intentionally not excluded\nSELECT 1 AS patient_id",
         "utf-8",
     )
     monkeypatch.setattr(

--- a/tests/test___main__.py
+++ b/tests/test___main__.py
@@ -1,0 +1,45 @@
+import pathlib
+
+from sqlrunner import T100S_TABLE
+from sqlrunner.__main__ import entrypoint
+
+
+def test_entrypoint(monkeypatch, tmp_path, dsn):
+    monkeypatch.chdir(tmp_path)
+    pathlib.Path("input.sql").write_text(
+        f"-- {T100S_TABLE} intentionally not excluded\nSELECT 1 AS patient_id",
+        "utf-8",
+    )
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "__main__",
+            "--output",
+            "output.csv",
+            "--log-file",
+            "log.json",
+            "input.sql",
+        ],
+    )
+    monkeypatch.setattr("os.environ", {"DATABASE_URL": dsn})
+    entrypoint()
+    assert pathlib.Path("output.csv").read_text("utf-8") == "patient_id\n1\n"
+    assert pathlib.Path("log.json").exists()
+
+
+def test_entrypoint_with_dummy_data_file(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    pathlib.Path("dummy_data.csv").write_text("patient_id\n1\n", "utf-8")
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "__main__",
+            "--output",
+            "output.csv",
+            "--dummy-data-file",
+            "dummy_data.csv",
+            "input.sql",
+        ],
+    )
+    entrypoint()
+    assert pathlib.Path("output.csv").read_text("utf-8") == "patient_id\n1\n"

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -32,13 +32,6 @@ def test_main_with_t1oos_not_handled(tmp_path):
         main.main({"input": input_})
 
 
-def test_read_text(tmp_path):
-    f_path = tmp_path / "query.sql"
-    f_path.write_text("SELECT 1 AS patient_id", "utf-8")
-    sql_query = main.read_text(f_path)
-    assert sql_query == "SELECT 1 AS patient_id"
-
-
 @pytest.mark.parametrize(
     "sql_query,are_t100s_handled",
     [

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -5,6 +5,13 @@ import pytest
 from sqlrunner import T1OOS_TABLE, main
 
 
+def test_main_with_t1oos_not_handled(tmp_path):
+    input_ = tmp_path / "query.sql"
+    input_.write_text("SELECT Patient_ID FROM Patient", "utf-8")
+    with pytest.raises(RuntimeError):
+        main.main({"input": input_})
+
+
 def test_main_with_dummy_data_file(tmp_path):
     input_ = tmp_path / "query.sql"
     input_.write_text(
@@ -23,13 +30,6 @@ def test_main_with_dummy_data_file(tmp_path):
         }
     )
     assert output.read_text("utf-8") == "patient_id\n1\n"
-
-
-def test_main_with_t1oos_not_handled(tmp_path):
-    input_ = tmp_path / "query.sql"
-    input_.write_text("SELECT Patient_ID FROM Patient", "utf-8")
-    with pytest.raises(RuntimeError):
-        main.main({"input": input_})
 
 
 @pytest.mark.parametrize(

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -102,19 +102,6 @@ def test_parse_dsn(dsn, port):
     assert parsed_dsn["port"] == port
 
 
-@pytest.fixture
-def dsn(mssql_database):
-    dialect = "mssql"
-    driver = "pymssql"
-    user = mssql_database["username"]
-    password = mssql_database["password"]
-    server = mssql_database["host_from_host"]
-    port = mssql_database["port_from_host"]
-    database = mssql_database["db_name"]
-    dsn = f"{dialect}+{driver}://{user}:{password}@{server}:{port}/{database}"
-    return dsn
-
-
 def test_run_sql_t1oos_handled(dsn, log_output):
     sql_query = f"""
         -- {T100S_TABLE} intentionally not excluded

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,38 +1,8 @@
 import gzip
-import pathlib
 
 import pytest
 
 from sqlrunner import T100S_TABLE, main
-
-
-def test_parse_args():
-    args = main.parse_args(
-        [
-            "--dsn",
-            "dialect+driver://user:password@server:port/database",
-            "--output",
-            "results.csv",
-            "query.sql",
-        ]
-    )
-    assert args.dsn == "dialect+driver://user:password@server:port/database"
-    assert args.input == pathlib.Path("query.sql")
-    assert args.output == pathlib.Path("results.csv")
-    assert args.dummy_data_file is None
-    assert args.log_file is None
-
-
-def test_parse_args_with_defaults_from_environ(monkeypatch):
-    args = main.parse_args(
-        ["--output", "results.csv", "query.sql"],
-        {"DATABASE_URL": "dialect+driver://user:password@server:port/database"},
-    )
-    assert args.dsn == "dialect+driver://user:password@server:port/database"
-    assert args.input == pathlib.Path("query.sql")
-    assert args.output == pathlib.Path("results.csv")
-    assert args.dummy_data_file is None
-    assert args.log_file is None
 
 
 def test_read_text(tmp_path):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -5,6 +5,14 @@ import pytest
 from sqlrunner import T100S_TABLE, main
 
 
+def test_main_with_dummy_data_file(tmp_path):
+    dummy_data_file = tmp_path / "dummy_data.csv"
+    dummy_data_file.write_text("patient_id\n1\n", "utf-8")
+    output = tmp_path / "results.csv"
+    main.main({"dsn": None, "dummy_data_file": dummy_data_file, "output": output})
+    assert output.read_text("utf-8") == "patient_id\n1\n"
+
+
 def test_read_text(tmp_path):
     f_path = tmp_path / "query.sql"
     f_path.write_text("SELECT 1 AS patient_id", "utf-8")

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -2,13 +2,13 @@ import gzip
 
 import pytest
 
-from sqlrunner import T100S_TABLE, main
+from sqlrunner import T1OOS_TABLE, main
 
 
 def test_main_with_dummy_data_file(tmp_path):
     input_ = tmp_path / "query.sql"
     input_.write_text(
-        f"-- {T100S_TABLE} intentionally not excluded\nSELECT Patient_ID FROM Patient",
+        f"-- {T1OOS_TABLE} intentionally not excluded\nSELECT Patient_ID FROM Patient",
         "utf-8",
     )
     dummy_data_file = tmp_path / "dummy_data.csv"
@@ -33,7 +33,7 @@ def test_main_with_t1oos_not_handled(tmp_path):
 
 
 @pytest.mark.parametrize(
-    "sql_query,are_t100s_handled",
+    "sql_query,are_t1oos_handled",
     [
         # not handled by query
         (
@@ -46,7 +46,7 @@ def test_main_with_t1oos_not_handled(tmp_path):
         (
             f"""
                 SELECT Patient_ID FROM Patient
-                WHERE Patient_ID NOT IN (SELECT Patient_ID FROM {T100S_TABLE})
+                WHERE Patient_ID NOT IN (SELECT Patient_ID FROM {T1OOS_TABLE})
             """,
             True,
         ),
@@ -61,7 +61,7 @@ def test_main_with_t1oos_not_handled(tmp_path):
         # handled by comment
         (
             f"""
-                -- {T100S_TABLE} intentionally not excluded
+                -- {T1OOS_TABLE} intentionally not excluded
                 SELECT Patient_ID FROM Patient
             """,
             True,
@@ -70,14 +70,14 @@ def test_main_with_t1oos_not_handled(tmp_path):
         # touch" approach
         (
             f"""
-                SELECT Patient_ID FROM {T100S_TABLE}
+                SELECT Patient_ID FROM {T1OOS_TABLE}
              """,
             True,
         ),
     ],
 )
-def test_are_t100s_handled(sql_query, are_t100s_handled):
-    assert main.are_t100s_handled(sql_query) == are_t100s_handled
+def test_are_t1oos_handled(sql_query, are_t1oos_handled):
+    assert main.are_t1oos_handled(sql_query) == are_t1oos_handled
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
#130 reminded me that SQL Runner has become rather gangly. In this PR, I attempt to make it less so by:

* Testing the core of the program
* Separating code into "outward-facing" (`__main__.py`) and "inward-facing" (`main.py`) modules
* Removing several low-value tests
* Raising T1OO errors in the core of the program
* Renaming T100 to T1OO[^1]

I'd suggest stepping through this PR commit-by-commit.

[^1]: I'm still annoyed at myself for making this error, and even worse, for making it inconsistently.