### PR TITLE
Add docker-build-for-os-cli recipe

### DIFF
--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Write VERSION file
         run: echo $VERSION > sqlrunner/VERSION
       - name: Build image
-        run: just docker-build
+        run: just docker-build "sqlrunner"
       - name: Test image
         run: docker run --rm $IMAGE_NAME --help
       - name: Log into GitHub Container Registry

--- a/justfile
+++ b/justfile
@@ -120,13 +120,18 @@ fix: devenv
 
 
 # build the sqlrunner docker image
-docker-build:
+docker-build image_name="sqlrunner-dev":
     #!/usr/bin/env bash
     set -euo pipefail
 
     [[ -v CI ]] && echo "::group::Build sqlrunner (click to view)" || echo "Build sqlrunner"
-    DOCKER_BUILDKIT=1 docker build . -t sqlrunner
+    DOCKER_BUILDKIT=1 docker build . --tag {{ image_name }}
     [[ -v CI ]] && echo "::endgroup::" || echo ""
+
+
+# build the sqlrunner docker image that can be used locally via the OpenSAFELY CLI
+docker-build-for-os-cli: docker-build
+    docker tag sqlrunner-dev ghcr.io/opensafely-core/sqlrunner:dev
 
 
 # Run the dev project


### PR DESCRIPTION
This commit first modifies the docker-build recipe to build the sqlrunner-dev image by default (and modifies the tag, build, and publish workflow to ensure that the sqlrunner image is still built on successful merge to main). It then adds a docker-build-for-os-cli recipe to tag the sqlrunner-dev image, such that sqlrunner:dev is picked up by the OpenSAFELY CLI (opensafely run, opensafely exec).

Why? So that we can make changes to a local SQL Runner, and test them against a local study. Doing so is useful when you want to debug odd SQL Runner behaviour in your local study.