### PR TITLE
Error if dsn and dummy-data-file are both missing

### DIFF
--- a/sqlrunner/__main__.py
+++ b/sqlrunner/__main__.py
@@ -72,6 +72,8 @@ def parse_args(args, environ):
 
 def entrypoint():
     args = parse_args(sys.argv[1:], os.environ)
+    if args["dsn"] is None and args["dummy_data_file"] is None:
+        raise RuntimeError("Neither --dsn nor --dummy-data-file were supplied")
 
     handlers = [logging.StreamHandler(sys.stdout)]
     # This is covered indirectly by a test.

--- a/tests/test___main__.py
+++ b/tests/test___main__.py
@@ -1,5 +1,7 @@
 import pathlib
 
+import pytest
+
 from sqlrunner import T1OOS_TABLE
 from sqlrunner.__main__ import entrypoint
 
@@ -25,3 +27,19 @@ def test_entrypoint(monkeypatch, tmp_path, dsn):
     entrypoint()
     assert pathlib.Path("output.csv").read_text("utf-8") == "patient_id\n1\n"
     assert pathlib.Path("log.json").exists()
+
+
+def test_entrypoint_with_missing_args(monkeypatch):
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "__main__",
+            "--output",
+            "output.csv",
+            "--log-file",
+            "log.json",
+            "input.sql",
+        ],
+    )
+    with pytest.raises(RuntimeError):
+        entrypoint()


### PR DESCRIPTION
Because we often want to supply both of these arguments -- for local/CI and production use -- we can't make them mutually exclusive. However, we want to raise an error (or, at least, raise a more informative error) if they are both missing, because it's impossible for SQL Runner to do anything useful.