### PR TITLE
Touch the log file

### DIFF
--- a/sqlrunner/__main__.py
+++ b/sqlrunner/__main__.py
@@ -6,7 +6,7 @@ import sys
 
 import structlog
 
-from sqlrunner import __version__, main
+from sqlrunner import __version__, main, utils
 
 
 # Configure structlog to output structured logs in JSON format. For more information,
@@ -82,7 +82,9 @@ def entrypoint():
     handlers = [logging.StreamHandler(sys.stdout)]
     # This is covered indirectly by a test.
     if args["log_file"] is not None:  # pragma: no cover
-        handlers.append(logging.FileHandler(args["log_file"], "w"))
+        log_file = args["log_file"]
+        utils.touch(log_file)
+        handlers.append(logging.FileHandler(log_file, "w"))
     logging.basicConfig(format="%(message)s", level=logging.INFO, handlers=handlers)
 
     main.main(args)

--- a/sqlrunner/main.py
+++ b/sqlrunner/main.py
@@ -9,7 +9,7 @@ from urllib import parse
 import pymssql
 import structlog
 
-from sqlrunner import T1OOS_TABLE
+from sqlrunner import T1OOS_TABLE, utils
 
 from .mssql_log_utils import execute_with_log
 
@@ -70,18 +70,13 @@ def run_sql(*, dsn, sql_query, include_statistics=False):
     conn.close()
 
 
-def touch(f_path):
-    f_path.parent.mkdir(parents=True, exist_ok=True)
-    f_path.touch()
-
-
 @functools.singledispatch
 def write_results(results, f_path):
     # job-runner expects the output CSV file to exist. If it doesn't, then the SQL
     # Runner action will fail. A user won't know whether their query returns any
     # results, so to avoid the SQL Runner action failing, we write an empty output CSV
     # file.
-    touch(f_path)
+    utils.touch(f_path)
 
     try:
         first_result = next(results)
@@ -110,5 +105,5 @@ def _(results: pathlib.Path, f_path):
     if f_path.exists() and f_path.samefile(results):
         return
 
-    touch(f_path)
+    utils.touch(f_path)
     shutil.copy(results, f_path)

--- a/sqlrunner/utils.py
+++ b/sqlrunner/utils.py
@@ -1,0 +1,4 @@
+def touch(f_path):
+    """Touch the file at the given path, making any parent directories as required."""
+    f_path.parent.mkdir(parents=True, exist_ok=True)
+    f_path.touch()


### PR DESCRIPTION
Although `FileHandler` touches the log file, it doesn't create any parent directories. If a user passes a path to the log file that includes non-existent parent directories, then SQL Runner will error with a `FileNotFoundError`. If SQL Runner touches the log file, making any parent directories as required, then it won't error.
