### PR TITLE
Generate column headers

### DIFF
--- a/requirements.prod.in
+++ b/requirements.prod.in
@@ -5,3 +5,4 @@
 
 pymssql
 structlog
+sqlglot

--- a/requirements.prod.txt
+++ b/requirements.prod.txt
@@ -67,6 +67,10 @@ pymssql==2.2.11 \
     --hash=sha256:fbca115e11685b5891755cc22b3db4348071b8d100a41e1ce93526d9c3dbf2d5 \
     --hash=sha256:fe0cc975aac87b364fdb55cb89642435c3e859dcd99d7260f48af94111ba2673
     # via -r requirements.prod.in
+sqlglot==20.4.0 \
+    --hash=sha256:401a2933298cf66901704cf2029272d8243ee72ac47b9fd8784254401b43ee43 \
+    --hash=sha256:9a42135d0530de8150a2c5106e0c52abd3396d92501ebe97df7b371d20de5dc9
+    # via -r requirements.prod.in
 structlog==23.3.0 \
     --hash=sha256:24b42b914ac6bc4a4e6f716e82ac70d7fb1e8c3b1035a765591953bfc37101a5 \
     --hash=sha256:d6922a88ceabef5b13b9eda9c4043624924f60edbb00397f4d193bd754cde60a


### PR DESCRIPTION
Fixes #93

This implementation elects to use the T-SQL dialect-specific parser (as spoken by mssql and thus TPP backend). The generic one fails on mssqlisms like square brackets around identifiers. This might not be compatible with other backends that speak other dialects.

`sqlglot`'s optimi~s~zer provides a `qualify_columns()` function that will (amongst other things) expand out `*`s into full column names which is what is needed to write out the dummy file header.

As implemented, there's no mutual exclusion between "running" the sql query and generating the column headers. This may or may not be the ideal. I considered making generate headers a subcommand which would then no longer require the output file arg, however I couldn't find an elegant way of not making this a breaking change to the CLI for the "run the query" path.

This implementation also [assumes](https://github.com/opensafely-core/sqlrunner/blob/8905154fa7bde9076d048371ab2420a03a8e6aa8/sqlrunner/main.py#L48) that there is only one `SELECT` statement in the input query file. However, other code paths also make this assumption.