### PR TITLE
Write to stdout if no output file arg provided

### DIFF
--- a/sqlrunner/main.py
+++ b/sqlrunner/main.py
@@ -1,9 +1,6 @@
 import csv
-import functools
 import gzip
 import itertools
-import pathlib
-import shutil
 from urllib import parse
 
 import pymssql
@@ -31,7 +28,7 @@ def main(args):
 
         else:
             # Bypass the database
-            results = args["dummy_data_file"]
+            results = read_dummy_data_file(args["dummy_data_file"])
     else:
         results = run_sql(
             dsn=args["dsn"],
@@ -97,7 +94,6 @@ def run_sql(*, dsn, sql_query, include_statistics=False):
     conn.close()
 
 
-@functools.singledispatch
 def write_results(results, f_path):
     # job-runner expects the output CSV file to exist. If it doesn't, then the SQL
     # Runner action will fail. A user won't know whether their query returns any
@@ -127,10 +123,7 @@ def write_results(results, f_path):
         f.close()
 
 
-@write_results.register
-def _(results: pathlib.Path, f_path):
-    if f_path.exists() and f_path.samefile(results):
-        return
-
-    utils.touch(f_path)
-    shutil.copy(results, f_path)
+def read_dummy_data_file(f_path):
+    with f_path.open("r") as f:
+        reader = csv.DictReader(f)
+        yield from reader

--- a/sqlrunner/main.py
+++ b/sqlrunner/main.py
@@ -1,6 +1,8 @@
 import csv
 import gzip
 import itertools
+import pathlib
+import sys
 from urllib import parse
 
 import pymssql
@@ -35,7 +37,8 @@ def main(args):
             sql_query=sql_query,
             include_statistics=args["include_statistics"],
         )
-    write_results(results, args["output"])
+    output = args["output"] or sys.stdout
+    write_results(results, output)
 
 
 def get_column_headers(sql_query):
@@ -94,12 +97,23 @@ def run_sql(*, dsn, sql_query, include_statistics=False):
     conn.close()
 
 
-def write_results(results, f_path):
-    # job-runner expects the output CSV file to exist. If it doesn't, then the SQL
-    # Runner action will fail. A user won't know whether their query returns any
-    # results, so to avoid the SQL Runner action failing, we write an empty output CSV
-    # file.
-    utils.touch(f_path)
+def write_results(results, destination):
+    dest_is_path = isinstance(destination, pathlib.Path)
+
+    if dest_is_path:
+        # If writing to file, job-runner expects the output CSV file to exist.
+        # If it doesn't, then the SQL Runner action will fail.
+        # A user won't know whether their query returns any results,
+        # so to avoid the SQL Runner action failing,
+        # we write an empty output CSV file.
+        utils.touch(destination)
+
+        if destination.suffixes == [".csv", ".gz"]:
+            destination = gzip.open(
+                destination, "wt", newline="", encoding="utf-8", compresslevel=6
+            )
+        else:
+            destination = destination.open(mode="w", newline="", encoding="utf-8")
 
     try:
         first_result = next(results)
@@ -108,19 +122,15 @@ def write_results(results, f_path):
 
     fieldnames = first_result.keys()
 
-    if f_path.suffixes == [".csv", ".gz"]:
-        f = gzip.open(f_path, "wt", newline="", encoding="utf-8", compresslevel=6)
-    else:
-        f = f_path.open(mode="w", newline="", encoding="utf-8")
-
     try:
-        writer = csv.DictWriter(f, fieldnames)
+        writer = csv.DictWriter(destination, fieldnames)
         log.info("start_writing_results")
         writer.writeheader()
         writer.writerows(itertools.chain([first_result], results))
         log.info("finish_writing_results")
     finally:
-        f.close()
+        if dest_is_path:
+            destination.close()
 
 
 def read_dummy_data_file(f_path):

--- a/sqlrunner/main.py
+++ b/sqlrunner/main.py
@@ -134,6 +134,6 @@ def write_results(results, destination):
 
 
 def read_dummy_data_file(f_path):
-    with f_path.open("r") as f:
+    with f_path.open("r", newline="") as f:
         reader = csv.DictReader(f)
         yield from reader

--- a/sqlrunner/main.py
+++ b/sqlrunner/main.py
@@ -135,5 +135,4 @@ def write_results(results, destination):
 
 def read_dummy_data_file(f_path):
     with f_path.open("r", newline="") as f:
-        reader = csv.DictReader(f)
-        yield from reader
+        yield from csv.DictReader(f)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -194,20 +194,11 @@ def test_write_results_compressed(output_path):
     assert gzip.open(f_path, "rt").read() == "id\n1\n2\n"
 
 
-@pytest.mark.parametrize(
-    "dummy_data_fname,results_fname",
-    [
-        ("results.csv", "results.csv"),
-        ("dummy_data_file.csv", "results.csv"),
-        ("results.csv", "subdir/results.csv"),
-    ],
-)
-def test_write_results_from_dummy_data_file(dummy_data_fname, results_fname, tmp_path):
-    dummy_data_file = tmp_path / dummy_data_fname
+def test_read_dummy_data_file(tmp_path):
+    dummy_data_file = tmp_path / "dummy_data_file.csv"
     dummy_data_file.write_text("id\n1\n2\n", encoding="utf-8")
-    results_file = tmp_path / results_fname
-    main.write_results(dummy_data_file, results_file)
-    assert results_file.read_text(encoding="utf-8") == "id\n1\n2\n"
+    dummy_rows = list(main.read_dummy_data_file(dummy_data_file))
+    assert dummy_rows == [{"id": "1"}, {"id": "2"}]
 
 
 @pytest.mark.parametrize(

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -50,6 +50,27 @@ def test_main_without_dummy_data_file(tmp_path):
     assert output.read_text("utf-8") == 'patient_id\n""\n'
 
 
+def test_main_with_dummy_data_file_to_stdout(capsys, tmp_path):
+    input_ = tmp_path / "query.sql"
+    input_.write_text(
+        f"-- {T1OOS_TABLE} intentionally not excluded\nSELECT Patient_ID FROM Patient",
+        "utf-8",
+    )
+    csv_lines = "patient_id\n1\n"
+    dummy_data_file = tmp_path / "dummy_data.csv"
+    dummy_data_file.write_text(csv_lines, "utf-8")
+    main.main(
+        {
+            "dsn": None,
+            "input": input_,
+            "dummy_data_file": dummy_data_file,
+            "output": None,
+        }
+    )
+    stdout = capsys.readouterr().out
+    assert stdout.replace("\r", "") == csv_lines
+
+
 @pytest.mark.parametrize(
     "sql_query,are_t1oos_handled",
     [


### PR DESCRIPTION
Fixes #98 

This required a few interconnected changes to make stdout behave like a file in all the ways we need it to so unfortunately is presented as a bit of a monster monolithic commit. 