### PR TITLE
Fix writing column headers

### DIFF
--- a/sqlrunner/__main__.py
+++ b/sqlrunner/__main__.py
@@ -76,8 +76,6 @@ def parse_args(args, environ):
 
 def entrypoint():
     args = parse_args(sys.argv[1:], os.environ)
-    if args["dsn"] is None and args["dummy_data_file"] is None:
-        raise RuntimeError("Neither --dsn nor --dummy-data-file were supplied")
 
     handlers = [logging.StreamHandler(sys.stdout)]
     if args["log_file"] is not None:

--- a/sqlrunner/__main__.py
+++ b/sqlrunner/__main__.py
@@ -80,8 +80,7 @@ def entrypoint():
         raise RuntimeError("Neither --dsn nor --dummy-data-file were supplied")
 
     handlers = [logging.StreamHandler(sys.stdout)]
-    # This is covered indirectly by a test.
-    if args["log_file"] is not None:  # pragma: no cover
+    if args["log_file"] is not None:
         log_file = args["log_file"]
         utils.touch(log_file)
         handlers.append(logging.FileHandler(log_file, "w"))

--- a/tests/test___main__.py
+++ b/tests/test___main__.py
@@ -75,5 +75,5 @@ def test_entrypoint_without_dsn_without_dummy_data_file(
 ):
     monkeypatch.chdir(tmp_path)
     monkeypatch.setattr("sys.argv", ["__main__", "--output", "output.csv", input_file])
-    with pytest.raises(RuntimeError):
-        entrypoint()
+    entrypoint()
+    assert pathlib.Path("output.csv").read_text("utf-8") == 'Patient_ID\n""\n'

--- a/tests/test___main__.py
+++ b/tests/test___main__.py
@@ -6,40 +6,74 @@ from sqlrunner import T1OOS_TABLE
 from sqlrunner.__main__ import entrypoint
 
 
-def test_entrypoint(monkeypatch, tmp_path, dsn):
+@pytest.fixture
+def input_file(monkeypatch, tmp_path):
     monkeypatch.chdir(tmp_path)
-    pathlib.Path("input.sql").write_text(
-        f"-- {T1OOS_TABLE} intentionally not excluded\nSELECT 1 AS patient_id",
+
+    path = pathlib.Path("input.sql")
+    path.write_text(
+        f"-- {T1OOS_TABLE} intentionally not excluded\nSELECT 1 AS Patient_ID",
         "utf-8",
     )
-    monkeypatch.setattr(
-        "sys.argv",
-        [
-            "__main__",
-            "--output",
-            "output.csv",
-            "--log-file",
-            "log.json",
-            "input.sql",
-        ],
-    )
+    return str(path)
+
+
+@pytest.mark.parametrize("pass_dummy_data_file", [False, True])
+def test_entrypoint_with_dsn(
+    monkeypatch, tmp_path, dsn, pass_dummy_data_file, input_file
+):
+    monkeypatch.chdir(tmp_path)
     monkeypatch.setattr("os.environ", {"DATABASE_URL": dsn})
+
+    argv = ["__main__", "--output", "output.csv", "--log-file", "log.json"]
+
+    if pass_dummy_data_file:
+        pathlib.Path("dummy_data.csv").touch()  # Notice the dummy data file is empty
+        argv.extend(["--dummy-data-file", "dummy_data.csv"])
+
+    argv.append(input_file)
+
+    monkeypatch.setattr("sys.argv", argv)
+
     entrypoint()
-    assert pathlib.Path("output.csv").read_text("utf-8") == "patient_id\n1\n"
+
+    # The dummy data file is empty, so we can be confident that the output file contains
+    # the result of executing the query in the input file against the database.
+    assert pathlib.Path("output.csv").read_text("utf-8") == "Patient_ID\n1\n"
+
+    # We test what is being logged elsewhere.
     assert pathlib.Path("log.json").exists()
 
 
-def test_entrypoint_with_missing_args(monkeypatch):
+def test_entrypoint_without_dsn_with_dummy_data_file(monkeypatch, tmp_path, input_file):
+    monkeypatch.chdir(tmp_path)
+
+    # The dummy data file and the query in the input file differ. Although this would be
+    # a bug in a study, it allows us to test that the output file doesn't contain the
+    # result of executing the query in the input file against the database.
+    pathlib.Path("dummy_data.csv").write_text("Sex\nF\n", "utf-8")
+
     monkeypatch.setattr(
         "sys.argv",
         [
             "__main__",
             "--output",
             "output.csv",
-            "--log-file",
-            "log.json",
-            "input.sql",
+            "--dummy-data-file",
+            "dummy_data.csv",
+            input_file,
         ],
     )
+
+    entrypoint()
+
+    assert pathlib.Path("output.csv").read_text("utf-8") == "Sex\nF\n"
+
+
+def test_entrypoint_without_dsn_without_dummy_data_file(
+    monkeypatch, tmp_path, input_file
+):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr("sys.argv", ["__main__", "--output", "output.csv", input_file])
     with pytest.raises(RuntimeError):
         entrypoint()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -12,44 +12,6 @@ def test_main_with_t1oos_not_handled(tmp_path):
         main.main({"input": input_})
 
 
-def test_main_with_dummy_data_file(tmp_path):
-    input_ = tmp_path / "query.sql"
-    input_.write_text(
-        f"-- {T1OOS_TABLE} intentionally not excluded\nSELECT patient_id FROM Patient",
-        "utf-8",
-    )
-    dummy_data_file = tmp_path / "dummy_data.csv"
-    dummy_data_file.write_text("patient_id\n1\n", "utf-8")
-    output = tmp_path / "results.csv"
-    main.main(
-        {
-            "dsn": None,
-            "input": input_,
-            "dummy_data_file": dummy_data_file,
-            "output": output,
-        }
-    )
-    assert output.read_text("utf-8") == "patient_id\n1\n"
-
-
-def test_main_without_dummy_data_file(tmp_path):
-    input_ = tmp_path / "query.sql"
-    input_.write_text(
-        f"-- {T1OOS_TABLE} intentionally not excluded\nSELECT patient_id FROM Patient",
-        "utf-8",
-    )
-    output = tmp_path / "results.csv"
-    main.main(
-        {
-            "dsn": None,
-            "input": input_,
-            "dummy_data_file": None,
-            "output": output,
-        }
-    )
-    assert output.read_text("utf-8") == 'patient_id\n""\n'
-
-
 def test_main_with_dummy_data_file_to_stdout(capsys, tmp_path):
     input_ = tmp_path / "query.sql"
     input_.write_text(


### PR DESCRIPTION
SQL Runner should write column headers when `dsn` and `dummy-data-file` are both None (#93). The check in `__main__.py` prevents that, so we remove the check and update the associated test (67a7a21).

To get to this commit, we add more comprehensive end-to-end tests (3e0d6c3). Why?

SQL Runner has three command-line arguments that determine its behaviour: `dsn`, `dummy-data-file`, and `output`. Each can take a string or None. In 3e0d6c3, we set `output` to a string (a path). Consequently, SQL Runner's behaviour is as follows:

| dsn  | dummy-data-file | Behaviour                         |
|------|-----------------|-----------------------------------|
| dsn  | path            | Query DB, write results to output |
| dsn  | None            | Query DB, write results to output |
| None | path            | Write dummy data file to output   |
| None | None            | Write column headers to output    |

Previously, we tested the dsn/None case and the None/None case. However, the end-to-end test for the None/None case didn't reflect the changes that were introduced by #93. 3e0d6c3 adds an end-to-end test for each case.

