### PR TITLE
Refactor `write_results`

### DIFF
--- a/sqlrunner/__main__.py
+++ b/sqlrunner/__main__.py
@@ -50,7 +50,6 @@ def parse_args(args, environ):
     )
     parser.add_argument(
         "--output",
-        required=True,
         type=pathlib.Path,
         help="Path to the output CSV file",
     )

--- a/sqlrunner/main.py
+++ b/sqlrunner/main.py
@@ -24,12 +24,10 @@ def main(args):
         raise RuntimeError("T1OOs are not handled correctly")
 
     if args["dsn"] is None:
+        # Bypass the database
         if args["dummy_data_file"] is None:
-            # Output dummy data file with header but no rows
             results = iter([{x: None for x in get_column_headers(sql_query)}])
-
         else:
-            # Bypass the database
             results = read_dummy_data_file(args["dummy_data_file"])
     else:
         results = run_sql(
@@ -37,6 +35,7 @@ def main(args):
             sql_query=sql_query,
             include_statistics=args["include_statistics"],
         )
+
     output = args["output"] or sys.stdout
     write_results(results, output)
 

--- a/sqlrunner/main.py
+++ b/sqlrunner/main.py
@@ -1,7 +1,7 @@
+import contextlib
 import csv
 import gzip
 import itertools
-import pathlib
 import sys
 from urllib import parse
 
@@ -36,8 +36,7 @@ def main(args):
             include_statistics=args["include_statistics"],
         )
 
-    output = args["output"] or sys.stdout
-    write_results(results, output)
+    write_results(results, args["output"])
 
 
 def get_column_headers(sql_query):
@@ -96,23 +95,13 @@ def run_sql(*, dsn, sql_query, include_statistics=False):
     conn.close()
 
 
-def write_results(results, destination):
-    dest_is_path = isinstance(destination, pathlib.Path)
-
-    if dest_is_path:
-        # If writing to file, job-runner expects the output CSV file to exist.
-        # If it doesn't, then the SQL Runner action will fail.
-        # A user won't know whether their query returns any results,
-        # so to avoid the SQL Runner action failing,
-        # we write an empty output CSV file.
-        utils.touch(destination)
-
-        if destination.suffixes == [".csv", ".gz"]:
-            destination = gzip.open(
-                destination, "wt", newline="", encoding="utf-8", compresslevel=6
-            )
-        else:
-            destination = destination.open(mode="w", newline="", encoding="utf-8")
+def write_results(results, f_path):
+    if f_path is not None:
+        # job-runner expects the output CSV file to exist. If it doesn't, then the SQL
+        # Runner action will fail. A user won't know whether their query returns any
+        # results, so to avoid the SQL Runner action failing, we write an empty output
+        # CSV file.
+        utils.touch(f_path)
 
     try:
         first_result = next(results)
@@ -121,15 +110,21 @@ def write_results(results, destination):
 
     fieldnames = first_result.keys()
 
-    try:
-        writer = csv.DictWriter(destination, fieldnames)
+    if f_path is not None:
+        kwargs = {"newline": "", "encoding": "utf-8"}
+        if f_path.suffixes == [".csv", ".gz"]:
+            context = gzip.open(f_path, "wt", compresslevel=6, **kwargs)
+        else:
+            context = open(f_path, "w", **kwargs)
+    else:
+        context = contextlib.nullcontext(sys.stdout)
+
+    with context as f:
+        writer = csv.DictWriter(f, fieldnames)
         log.info("start_writing_results")
         writer.writeheader()
         writer.writerows(itertools.chain([first_result], results))
         log.info("finish_writing_results")
-    finally:
-        if dest_is_path:
-            destination.close()
 
 
 def read_dummy_data_file(f_path):

--- a/tests/test___main__.py
+++ b/tests/test___main__.py
@@ -77,3 +77,13 @@ def test_entrypoint_without_dsn_without_dummy_data_file(
     monkeypatch.setattr("sys.argv", ["__main__", "--output", "output.csv", input_file])
     entrypoint()
     assert pathlib.Path("output.csv").read_text("utf-8") == 'Patient_ID\n""\n'
+
+
+def test_entrypoint_without_output(monkeypatch, tmp_path, input_file, capsys):
+    # Without dsn, dummy-data-file, and (as the name of the test states) output. We
+    # expect column headers to be written to stdout
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr("sys.argv", ["__main__", input_file])
+    entrypoint()
+    out, _ = capsys.readouterr()
+    assert out == 'Patient_ID\r\n""\r\n'

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -12,27 +12,6 @@ def test_main_with_t1oos_not_handled(tmp_path):
         main.main({"input": input_})
 
 
-def test_main_with_dummy_data_file_to_stdout(capsys, tmp_path):
-    input_ = tmp_path / "query.sql"
-    input_.write_text(
-        f"-- {T1OOS_TABLE} intentionally not excluded\nSELECT Patient_ID FROM Patient",
-        "utf-8",
-    )
-    csv_lines = "patient_id\n1\n"
-    dummy_data_file = tmp_path / "dummy_data.csv"
-    dummy_data_file.write_text(csv_lines, "utf-8")
-    main.main(
-        {
-            "dsn": None,
-            "input": input_,
-            "dummy_data_file": dummy_data_file,
-            "output": None,
-        }
-    )
-    stdout = capsys.readouterr().out
-    assert stdout.replace("\r", "") == csv_lines
-
-
 @pytest.mark.parametrize(
     "sql_query,are_t1oos_handled",
     [


### PR DESCRIPTION
This refactors the `write_results` function, and returns it to its signature prior to #160. We want to output to stdout, if an output file isn't supplied. Whilst `sys.stdout` behaves like a file-like object, we don't want to close it, as we would an output file. Rather than accomplish this through type checking and try/finally, we instead use a different context manager to output to `sys.stdout`. Hopefully, doing so makes the `write_results` function easier to reason about.

(This is the approach we take to outputting to stdout in ehrQL. See [the `write_dataset_csv` function][1].)

[1]: https://github.com/opensafely-core/ehrql/blob/e863a3409c6c0473109dbfe3d1567c50eacb9b30/ehrql/file_formats/csv.py#L10-L18