### PR TITLE
Switch to inclusion table for T1OO handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ To exclude T1OO data, for example:
 ```sql
 SELECT <select_list>
 FROM Patient
-WHERE Patient_ID NOT IN (SELECT Patient_ID FROM PatientsWithTypeOneDissent)
+WHERE Patient_ID IN (SELECT Patient_ID FROM AllowedPatientsWithTypeOneDissent)
 GROUP BY <group_by_clause>
 ORDER BY <order_by_expression>
 ```
@@ -24,12 +24,16 @@ To explain why T1OO data haven't been excluded, for example:
 
 ```sql
 -- This query is for a data development project that must include T1OO data.
--- Consequently, this query doesn't reference the PatientsWithTypeOneDissent table.
+-- Consequently, this query doesn't reference the AllowedPatientsWithTypeOneDissent table.
 SELECT <select_list>
 FROM Patient
 GROUP BY <group_by_clause>
 ORDER BY <order_by_expression>
 ```
+
+Note that the table has its name for historical reasons, and reads
+slightly oddly: it should be interpreted as "allowed patients with
+regard to type one dissents".
 
 ## Notes for developers
 

--- a/sqlrunner/__init__.py
+++ b/sqlrunner/__init__.py
@@ -3,4 +3,7 @@ from pathlib import Path
 
 __version__ = Path(__file__).parent.joinpath("VERSION").read_text().strip()
 
-T1OOS_TABLE = "PatientsWithTypeOneDissent"
+
+# This table has its name for historical reasons, and reads slightly oddly: it should be
+# interpreted as "allowed patients with regard to type one dissents"
+T1OOS_TABLE = "AllowedPatientsWithTypeOneDissent"

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -26,7 +26,7 @@ def test_main_with_t1oos_not_handled(tmp_path):
         (
             f"""
                 SELECT Patient_ID FROM Patient
-                WHERE Patient_ID NOT IN (SELECT Patient_ID FROM {T1OOS_TABLE})
+                WHERE Patient_ID IN (SELECT Patient_ID FROM {T1OOS_TABLE})
             """,
             True,
         ),
@@ -50,7 +50,8 @@ def test_main_with_t1oos_not_handled(tmp_path):
         # touch" approach
         (
             f"""
-                SELECT Patient_ID FROM {T1OOS_TABLE}
+                SELECT Patient_ID FROM Patient
+                WHERE Patient_ID NOT IN (SELECT Patient_ID FROM {T1OOS_TABLE})
              """,
             True,
         ),


### PR DESCRIPTION
This switches the T1OO logic to use a table of explicitly _allowed_ patients, rather than a table of exclusions. This allows TPP to apply more complex criteria in determining the appropriate set of patients.

All existing projects using SQL Runner will now refuse to run until they're updated to use the new table name (this seems like the behaviour we want, although it's a bit more work). I'll create PRs for these projects separately. 