### PR TITLE
Update the version of mssql used in tests

### DIFF
--- a/tests/databases.py
+++ b/tests/databases.py
@@ -58,7 +58,12 @@ def make_mssql_database(containers):
 def run_mssql(container_name, containers, password, mssql_port):  # pragma: no cover
     containers.run_bg(
         name=container_name,
-        image="mcr.microsoft.com/mssql/server:2017-CU25-ubuntu-16.04",
+        # This is *not* the version that TPP run for us in production which, as of
+        # 2024-09-24, is SQL Server 2016 (13.0.5893.48). That version is not available
+        # as a Docker image, so we run the oldest supported version instead. Both the
+        # production server and our test server set the "compatibility level" to the
+        # same value so the same feature set should be supported.
+        image="mcr.microsoft.com/mssql/server:2019-CU28-ubuntu-20.04",
         volumes={
             MSSQL_SETUP_DIR: {"bind": "/mssql", "mode": "ro"},
         },

--- a/tests/support/mssql/entrypoint.sh
+++ b/tests/support/mssql/entrypoint.sh
@@ -16,7 +16,7 @@ if [ "$1" = '/opt/mssql/bin/sqlservr' ]; then
         timeout=20
         limit="$((SECONDS + timeout))"
         # Run the setup script to create the DB and the schema in the DB
-        until /opt/mssql-tools/bin/sqlcmd -S localhost -U SA -P "Your_password123!" -d master -i /mssql/setup.sql; do
+        until /opt/mssql-tools18/bin/sqlcmd -S localhost -U SA -P "Your_password123!" -d master -C -i /mssql/setup.sql; do
           # Wait a bit for SQL Server to start. SQL Server's process
           # doesn't provide a clever way to check if it's up or not, and
           # it needs to be up before we can import the application


### PR DESCRIPTION
Copying the commit message from the equivalent PR on ehrql: https://github.com/opensafely-core/ehrql/pull/2120

The previous version was incompatible with the updated kernel now used by Github Actions runners. See:
microsoft/mssql-docker#868

The fix has been backported as far as the 2019 image, but not to the 2017 image. Seeing that the 2017 image didn't match what was being run in production in any case we might as well upgrade.

This requires a few small changes:

 * The `sqlcmd` tool has moved from `/opt/mssql-tools/bin` to `/opt/mssql-tools18/bin`. This is due to the newer image using the `mssql-tools18` apt package.

 * The `sqlcmd` invocation now requires the `-C` option to automatically trust the server certificate.