### PR TITLE
Don't run the automerge step for update-dependencies PR

### DIFF
--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -24,3 +24,4 @@ jobs:
     - uses: opensafely-core/update-dependencies-action@v1
       with:
         token: ${{ steps.generate-token.outputs.token }}
+        automerge: false


### PR DESCRIPTION
Automerge is not enabled on this repo.