### PR TITLE
Check for PatientsWithTypeOneDissent in query

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ To exclude T1OO data, for example:
 ```sql
 SELECT <select_list>
 FROM Patient
-WHERE Patient_ID IN (SELECT Patient_ID FROM AllowedPatientsWithTypeOneDissent)
+WHERE Patient_ID NOT IN (SELECT Patient_ID FROM PatientsWithTypeOneDissent)
 GROUP BY <group_by_clause>
 ORDER BY <order_by_expression>
 ```
@@ -24,16 +24,12 @@ To explain why T1OO data haven't been excluded, for example:
 
 ```sql
 -- This query is for a data development project that must include T1OO data.
--- Consequently, this query doesn't reference the AllowedPatientsWithTypeOneDissent table.
+-- Consequently, this query doesn't reference the PatientsWithTypeOneDissent table.
 SELECT <select_list>
 FROM Patient
 GROUP BY <group_by_clause>
 ORDER BY <order_by_expression>
 ```
-
-Note that the table has its name for historical reasons, and reads
-slightly oddly: it should be interpreted as "allowed patients with
-regard to type one dissents".
 
 ## Notes for developers
 

--- a/sqlrunner/__init__.py
+++ b/sqlrunner/__init__.py
@@ -3,4 +3,9 @@ from pathlib import Path
 
 __version__ = Path(__file__).parent.joinpath("VERSION").read_text().strip()
 
+# This is the name of the table listing patients with T1OOs.
 T1OOS_TABLE = "PatientsWithTypeOneDissent"
+
+# Previously we were given a table listing patients without T1OOs.
+# The name should be interpreted as "allowed patients with regard to type one dissents".
+OLD_T1OOS_TABLE = "AllowedPatientsWithTypeOneDissent"

--- a/sqlrunner/__init__.py
+++ b/sqlrunner/__init__.py
@@ -3,7 +3,4 @@ from pathlib import Path
 
 __version__ = Path(__file__).parent.joinpath("VERSION").read_text().strip()
 
-
-# This table has its name for historical reasons, and reads slightly oddly: it should be
-# interpreted as "allowed patients with regard to type one dissents"
-T1OOS_TABLE = "AllowedPatientsWithTypeOneDissent"
+T1OOS_TABLE = "PatientsWithTypeOneDissent"

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -3,7 +3,7 @@ import gzip
 
 import pytest
 
-from sqlrunner import T1OOS_TABLE, main
+from sqlrunner import OLD_T1OOS_TABLE, T1OOS_TABLE, main
 
 
 def test_main_with_t1oos_not_handled(tmp_path):
@@ -31,6 +31,14 @@ def test_main_with_t1oos_not_handled(tmp_path):
             """,
             True,
         ),
+        # handled incorrectly by query (uses the old name)
+        (
+            f"""
+                SELECT Patient_ID FROM Patient
+                WHERE Patient_ID IN (SELECT Patient_ID FROM {OLD_T1OOS_TABLE})
+            """,
+            False,
+        ),
         # not handled by comment
         (
             """
@@ -43,6 +51,14 @@ def test_main_with_t1oos_not_handled(tmp_path):
         (
             f"""
                 -- {T1OOS_TABLE} intentionally not excluded
+                SELECT Patient_ID FROM Patient
+            """,
+            True,
+        ),
+        # handled by comment via old name
+        (
+            f"""
+                -- {OLD_T1OOS_TABLE} intentionally not excluded
                 SELECT Patient_ID FROM Patient
             """,
             True,

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -27,7 +27,7 @@ def test_main_with_t1oos_not_handled(tmp_path):
         (
             f"""
                 SELECT Patient_ID FROM Patient
-                WHERE Patient_ID IN (SELECT Patient_ID FROM {T1OOS_TABLE})
+                WHERE Patient_ID NOT IN (SELECT Patient_ID FROM {T1OOS_TABLE})
             """,
             True,
         ),
@@ -51,8 +51,7 @@ def test_main_with_t1oos_not_handled(tmp_path):
         # touch" approach
         (
             f"""
-                SELECT Patient_ID FROM Patient
-                WHERE Patient_ID NOT IN (SELECT Patient_ID FROM {T1OOS_TABLE})
+                SELECT Patient_ID FROM {T1OOS_TABLE}
              """,
             True,
         ),


### PR DESCRIPTION
The name of the table we are checking against has changed back to `PatientsWithTypeOneDissent`.

We want to check for both the old and the new name in comments, so that we don't have to change existing queries that reference the old name to explain why T1OO data haven't been excluded.