### PR TITLE
Add missing workflow step id

### DIFF
--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -22,6 +22,7 @@ jobs:
         private-key: ${{ secrets.CREATE_PR_APP_PRIVATE_KEY }}
 
     - uses: bennettoxford/update-dependencies-action@v1
+      id: update
       with:
         token: ${{ steps.generate-token.outputs.token }}
 


### PR DESCRIPTION
The slack notification step needs this in order to post the PR url.